### PR TITLE
Remove workers config to allow parallel execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: npm i @replayio/playwright
+    - run: npm i @replayio/playwright@">=0.2.0"
       shell: sh
-    - run: ${{ inputs.command }} --project ${{ inputs.project }} --reporter=line,@replayio/playwright/reporter --workers=1
+    - run: ${{ inputs.command }} --project ${{ inputs.project }} --reporter=line,@replayio/playwright/reporter
       shell: sh
       working-directory: ${{ inputs.working-directory }}
     - name: 'Upload Recordings'


### PR DESCRIPTION
Blocked by https://github.com/Replayio/replay-cli/pull/16

## Issue

We restrict the number of workers because we didn't have an ability to identify to which test a recording belongs

## Resolution

This has been fixed by the `0.2.0` version of the reporter so we can remove that restriction now