### PR TITLE
Change default project to replay-chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   with:
     apiKey: ${{ secrets.RECORD_REPLAY_API_KEY }}
     issue-number: ${{ github.event.pull_request.number }}
-    project: replay-firefox
+    project: replay-chromium
 ```
 
 ## Arguments
@@ -64,7 +64,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           # The `@playwright/test` project to use. This should point to a project
           # that uses a Replay runtime.
-          project: replay-firefox
+          project: replay-chromium
           # An API key (usually a Team API Key) to use to upload replays.
           # Configure this via GitHub repo settings.
           apiKey: ${{ secrets.RECORD_REPLAY_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: "npx playwright test"
   project:
     description: "Project for replay browser"
-    default: "replay-firefox"
+    default: "replay-chromium"
   issue-number:
     description: "Pull Request on which to comment results"
   apiKey:


### PR DESCRIPTION
Our chromium fork runs quite a bit faster than gecko so I'm swapping over the default to chromium for the time being.

see https://github.com/RecordReplay/ops/issues/742#issuecomment-1105860965