### PR TITLE
Fix upload filter for new metadata structure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
         RECORD_REPLAY_TEST_RUN_ID: ${{ steps.test-run-id.outputs.UUID }}
     - name: 'Upload Recordings'
       id: 'upload-recordings'
-      uses: replayio/action-upload@v0.2.5
+      uses: replayio/action-upload@v0.2.6
       if: ${{ always() }}
       with:
         apiKey: ${{ inputs.apiKey }}

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       with:
         apiKey: ${{ inputs.apiKey }}
         public: ${{ inputs.public }}
-        filter: ${{ !inputs.upload-all && 'function($v) { $v.metadata.testStatus = "failed" and $v.status = "onDisk" }' || '' }}
+        filter: ${{ !inputs.upload-all && 'function($v) { $v.metadata.test.result = "failed" and $v.status = "onDisk" }' || 'function($v) { $v.metadata.test.result and $v.status = "onDisk" }' }}
       env:
         RECORD_REPLAY_API_KEY: ${{ inputs.apiKey }}
     - name: 'Comment PR'


### PR DESCRIPTION
* Fix filter to look for the right path for test result
* When `upload-all` is set, only upload recordings with a test result to avoid spurious recordings